### PR TITLE
feat: add Bytes

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ As an added bonus using them as their base type eg. String => string, you have t
 
 Variables:
 - `String` - The most useful
+- `Bytes`
 - `Bool`
 - `Float32`
 - `Float64`

--- a/bytes.go
+++ b/bytes.go
@@ -27,6 +27,6 @@ func (s Bytes) MarshalJSON() ([]byte, error) {
 
 func (s Bytes) MarshalText() (text []byte, err error) {
 	var ss State
-	s.Format(&ss, 's')
+	s.Format(&ss, 'X')
 	return ss.b, nil
 }

--- a/bytes.go
+++ b/bytes.go
@@ -1,0 +1,32 @@
+package sensitive
+
+import (
+	"encoding"
+	"encoding/json"
+	"fmt"
+)
+
+var (
+	_             fmt.Formatter          = (*Bytes)(nil)
+	_             json.Marshaler         = (*Bytes)(nil)
+	_             encoding.TextMarshaler = (*Bytes)(nil)
+	FormatBytesFn                        = func(s Bytes, f fmt.State, c rune) {}
+)
+
+type Bytes []byte
+
+func (s Bytes) Format(f fmt.State, c rune) {
+	FormatBytesFn(s, f, c)
+}
+
+func (s Bytes) MarshalJSON() ([]byte, error) {
+	var ss State
+	s.Format(&ss, 's')
+	return json.Marshal(ss.b)
+}
+
+func (s Bytes) MarshalText() (text []byte, err error) {
+	var ss State
+	s.Format(&ss, 's')
+	return ss.b, nil
+}

--- a/bytes_test.go
+++ b/bytes_test.go
@@ -1,0 +1,169 @@
+package sensitive
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestBytesFormatting(t *testing.T) {
+	assert := require.New(t)
+	value := Bytes("value")
+	var empty *Bytes
+
+	tests := []struct {
+		name       string
+		formatting string
+		expected   string
+		value      interface{}
+	}{
+		{
+			name:       "Bytes %s",
+			formatting: "%s",
+			value:      value,
+		},
+		{
+			name:       "Bytes %q",
+			formatting: "%q",
+			value:      value,
+		},
+		{
+			name:       "Bytes %v",
+			formatting: "%v",
+			value:      value,
+		},
+		{
+			name:       "Bytes %#v",
+			formatting: "%#v",
+			value:      value,
+		},
+		{
+			name:       "Bytes %x",
+			formatting: "%x",
+			value:      value,
+		},
+		{
+			name:       "Bytes %X",
+			formatting: "%X",
+			value:      value,
+		},
+		{
+			name:       "Bytes %T",
+			formatting: "%T",
+			value:      value,
+			expected:   "sensitive.Bytes",
+		},
+		{
+			name:       "Ptr Bytes %s",
+			formatting: "%s",
+			value:      empty,
+			expected:   "<nil>",
+		},
+		{
+			name:       "Ptr Bytes %q",
+			formatting: "%q",
+			value:      empty,
+			expected:   "<nil>",
+		},
+		{
+			name:       "Ptr Bytes %v",
+			formatting: "%v",
+			value:      empty,
+			expected:   "<nil>",
+		},
+		{
+			name:       "Ptr Bytes %#v",
+			formatting: "%#v",
+			value:      empty,
+			expected:   "<nil>",
+		},
+		{
+			name:       "Ptr Bytes %x",
+			formatting: "%x",
+			value:      empty,
+			expected:   "<nil>",
+		},
+		{
+			name:       "Ptr Bytes %X",
+			formatting: "%X",
+			value:      empty,
+			expected:   "<nil>",
+		},
+		{
+			name:       "Ptr Bytes %T",
+			formatting: "%T",
+			value:      empty,
+			expected:   "*sensitive.Bytes",
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			result := fmt.Sprintf(tc.formatting, tc.value)
+			assert.Equal(tc.expected, result)
+		})
+	}
+}
+
+func TestBytesJSON(t *testing.T) {
+	assert := require.New(t)
+	value := Bytes("value")
+
+	b, err := json.Marshal(value)
+	assert.NoError(err)
+	assert.Equal("null", string(b))
+
+	var empty *Bytes
+	b, err = json.Marshal(empty)
+	assert.NoError(err)
+	assert.Equal("null", string(b))
+}
+
+func TestBytesCustomFormatFn(t *testing.T) {
+	assert := require.New(t)
+
+	oldFn := FormatBytesFn
+	defer func() {
+		FormatBytesFn = oldFn
+	}()
+	FormatBytesFn = func(s Bytes, f fmt.State, c rune) {
+		_, _ = f.Write([]byte("blah"))
+	}
+
+	value := Bytes("value")
+	b, err := json.Marshal(value)
+	assert.NoError(err)
+	assert.Equal("\"YmxhaA==\"", string(b))
+}
+
+func BenchmarkBytes_Format(b *testing.B) {
+	value := Bytes("value")
+	for i := 0; i < b.N; i++ {
+		_ = fmt.Sprintf("%s", value)
+	}
+}
+
+func BenchmarkBytes_FormatNative(b *testing.B) {
+	value := "value"
+	for i := 0; i < b.N; i++ {
+		_ = fmt.Sprintf("%s", value)
+	}
+}
+
+func BenchmarkBytesJSON(b *testing.B) {
+	value := Bytes("value")
+	for i := 0; i < b.N; i++ {
+		_, _ = json.Marshal(value)
+	}
+}
+
+func BenchmarkBytes_JSONNative(b *testing.B) {
+	value := "value"
+	for i := 0; i < b.N; i++ {
+		_, _ = json.Marshal(value)
+	}
+}


### PR DESCRIPTION
I belive we also need to mention one more case in README in addition to args/ENV: values received using network gRPC/HTTP API (which often contains passwords and tokens) or somehow generated (think salt and hashed passwords). These values shouldn't be occasionally logged too. And here we sometimes need `[]byte`, added by this PR.

I'm not a native English speaker, so I think it'll be better if you'll do mentioned above README update yourself, if you like the idea.