### PR TITLE
fix: marshal result of Format*Fn for all types

### DIFF
--- a/bool.go
+++ b/bool.go
@@ -4,6 +4,7 @@ import (
 	"encoding"
 	"encoding/json"
 	"fmt"
+	"strconv"
 )
 
 var (
@@ -20,11 +21,20 @@ func (s Bool) Format(f fmt.State, c rune) {
 }
 
 func (s Bool) MarshalJSON() ([]byte, error) {
-	return json.Marshal(nil)
+	var ss State
+	s.Format(&ss, 'v')
+	if len(ss.b) == 0 {
+		return json.Marshal(nil)
+	}
+	v, err := strconv.ParseBool(string(ss.b))
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(v)
 }
 
 func (s Bool) MarshalText() (text []byte, err error) {
 	var ss State
-	s.Format(&ss, 's')
+	s.Format(&ss, 'v')
 	return ss.b, nil
 }

--- a/float32.go
+++ b/float32.go
@@ -4,6 +4,7 @@ import (
 	"encoding"
 	"encoding/json"
 	"fmt"
+	"strconv"
 )
 
 var (
@@ -20,11 +21,20 @@ func (s Float32) Format(f fmt.State, c rune) {
 }
 
 func (s Float32) MarshalJSON() ([]byte, error) {
-	return json.Marshal(nil)
+	var ss State
+	s.Format(&ss, 'v')
+	if len(ss.b) == 0 {
+		return json.Marshal(nil)
+	}
+	v, err := strconv.ParseFloat(string(ss.b), 32)
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(float32(v))
 }
 
 func (s Float32) MarshalText() (text []byte, err error) {
 	var ss State
-	s.Format(&ss, 's')
+	s.Format(&ss, 'v')
 	return ss.b, nil
 }

--- a/float64.go
+++ b/float64.go
@@ -4,6 +4,7 @@ import (
 	"encoding"
 	"encoding/json"
 	"fmt"
+	"strconv"
 )
 
 var (
@@ -20,11 +21,20 @@ func (s Float64) Format(f fmt.State, c rune) {
 }
 
 func (s Float64) MarshalJSON() ([]byte, error) {
-	return json.Marshal(nil)
+	var ss State
+	s.Format(&ss, 'v')
+	if len(ss.b) == 0 {
+		return json.Marshal(nil)
+	}
+	v, err := strconv.ParseFloat(string(ss.b), 64)
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(v)
 }
 
 func (s Float64) MarshalText() (text []byte, err error) {
 	var ss State
-	s.Format(&ss, 's')
+	s.Format(&ss, 'v')
 	return ss.b, nil
 }

--- a/int.go
+++ b/int.go
@@ -4,6 +4,7 @@ import (
 	"encoding"
 	"encoding/json"
 	"fmt"
+	"strconv"
 )
 
 var (
@@ -20,11 +21,20 @@ func (s Int) Format(f fmt.State, c rune) {
 }
 
 func (s Int) MarshalJSON() ([]byte, error) {
-	return json.Marshal(nil)
+	var ss State
+	s.Format(&ss, 'v')
+	if len(ss.b) == 0 {
+		return json.Marshal(nil)
+	}
+	v, err := strconv.ParseInt(string(ss.b), 10, 0)
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(int(v))
 }
 
 func (s Int) MarshalText() (text []byte, err error) {
 	var ss State
-	s.Format(&ss, 's')
+	s.Format(&ss, 'v')
 	return ss.b, nil
 }

--- a/int16.go
+++ b/int16.go
@@ -4,6 +4,7 @@ import (
 	"encoding"
 	"encoding/json"
 	"fmt"
+	"strconv"
 )
 
 var (
@@ -20,11 +21,20 @@ func (s Int16) Format(f fmt.State, c rune) {
 }
 
 func (s Int16) MarshalJSON() ([]byte, error) {
-	return json.Marshal(nil)
+	var ss State
+	s.Format(&ss, 'v')
+	if len(ss.b) == 0 {
+		return json.Marshal(nil)
+	}
+	v, err := strconv.ParseInt(string(ss.b), 10, 16)
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(int16(v))
 }
 
 func (s Int16) MarshalText() (text []byte, err error) {
 	var ss State
-	s.Format(&ss, 's')
+	s.Format(&ss, 'v')
 	return ss.b, nil
 }

--- a/int32.go
+++ b/int32.go
@@ -4,6 +4,7 @@ import (
 	"encoding"
 	"encoding/json"
 	"fmt"
+	"strconv"
 )
 
 var (
@@ -20,11 +21,20 @@ func (s Int32) Format(f fmt.State, c rune) {
 }
 
 func (s Int32) MarshalJSON() ([]byte, error) {
-	return json.Marshal(nil)
+	var ss State
+	s.Format(&ss, 'v')
+	if len(ss.b) == 0 {
+		return json.Marshal(nil)
+	}
+	v, err := strconv.ParseInt(string(ss.b), 10, 32)
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(int32(v))
 }
 
 func (s Int32) MarshalText() (text []byte, err error) {
 	var ss State
-	s.Format(&ss, 's')
+	s.Format(&ss, 'v')
 	return ss.b, nil
 }

--- a/int64.go
+++ b/int64.go
@@ -4,6 +4,7 @@ import (
 	"encoding"
 	"encoding/json"
 	"fmt"
+	"strconv"
 )
 
 var (
@@ -20,11 +21,20 @@ func (s Int64) Format(f fmt.State, c rune) {
 }
 
 func (s Int64) MarshalJSON() ([]byte, error) {
-	return json.Marshal(nil)
+	var ss State
+	s.Format(&ss, 'v')
+	if len(ss.b) == 0 {
+		return json.Marshal(nil)
+	}
+	v, err := strconv.ParseInt(string(ss.b), 10, 64)
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(v)
 }
 
 func (s Int64) MarshalText() (text []byte, err error) {
 	var ss State
-	s.Format(&ss, 's')
+	s.Format(&ss, 'v')
 	return ss.b, nil
 }

--- a/int8.go
+++ b/int8.go
@@ -4,6 +4,7 @@ import (
 	"encoding"
 	"encoding/json"
 	"fmt"
+	"strconv"
 )
 
 var (
@@ -20,11 +21,20 @@ func (s Int8) Format(f fmt.State, c rune) {
 }
 
 func (s Int8) MarshalJSON() ([]byte, error) {
-	return json.Marshal(nil)
+	var ss State
+	s.Format(&ss, 'v')
+	if len(ss.b) == 0 {
+		return json.Marshal(nil)
+	}
+	v, err := strconv.ParseInt(string(ss.b), 10, 8)
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(int8(v))
 }
 
 func (s Int8) MarshalText() (text []byte, err error) {
 	var ss State
-	s.Format(&ss, 's')
+	s.Format(&ss, 'v')
 	return ss.b, nil
 }

--- a/string.go
+++ b/string.go
@@ -21,12 +21,12 @@ func (s String) Format(f fmt.State, c rune) {
 
 func (s String) MarshalJSON() ([]byte, error) {
 	var ss State
-	s.Format(&ss, 's')
+	s.Format(&ss, 'v')
 	return json.Marshal(string(ss.b))
 }
 
 func (s String) MarshalText() (text []byte, err error) {
 	var ss State
-	s.Format(&ss, 's')
+	s.Format(&ss, 'v')
 	return ss.b, nil
 }

--- a/uint.go
+++ b/uint.go
@@ -4,6 +4,7 @@ import (
 	"encoding"
 	"encoding/json"
 	"fmt"
+	"strconv"
 )
 
 var (
@@ -20,11 +21,20 @@ func (s Uint) Format(f fmt.State, c rune) {
 }
 
 func (s Uint) MarshalJSON() ([]byte, error) {
-	return json.Marshal(nil)
+	var ss State
+	s.Format(&ss, 'v')
+	if len(ss.b) == 0 {
+		return json.Marshal(nil)
+	}
+	v, err := strconv.ParseUint(string(ss.b), 10, 0)
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(uint(v))
 }
 
 func (s Uint) MarshalText() (text []byte, err error) {
 	var ss State
-	s.Format(&ss, 's')
+	s.Format(&ss, 'v')
 	return ss.b, nil
 }

--- a/uint16.go
+++ b/uint16.go
@@ -4,6 +4,7 @@ import (
 	"encoding"
 	"encoding/json"
 	"fmt"
+	"strconv"
 )
 
 var (
@@ -20,11 +21,20 @@ func (s Uint16) Format(f fmt.State, c rune) {
 }
 
 func (s Uint16) MarshalJSON() ([]byte, error) {
-	return json.Marshal(nil)
+	var ss State
+	s.Format(&ss, 'v')
+	if len(ss.b) == 0 {
+		return json.Marshal(nil)
+	}
+	v, err := strconv.ParseUint(string(ss.b), 10, 16)
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(uint16(v))
 }
 
 func (s Uint16) MarshalText() (text []byte, err error) {
 	var ss State
-	s.Format(&ss, 's')
+	s.Format(&ss, 'v')
 	return ss.b, nil
 }

--- a/uint32.go
+++ b/uint32.go
@@ -4,6 +4,7 @@ import (
 	"encoding"
 	"encoding/json"
 	"fmt"
+	"strconv"
 )
 
 var (
@@ -20,11 +21,20 @@ func (s Uint32) Format(f fmt.State, c rune) {
 }
 
 func (s Uint32) MarshalJSON() ([]byte, error) {
-	return json.Marshal(nil)
+	var ss State
+	s.Format(&ss, 'v')
+	if len(ss.b) == 0 {
+		return json.Marshal(nil)
+	}
+	v, err := strconv.ParseUint(string(ss.b), 10, 32)
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(uint32(v))
 }
 
 func (s Uint32) MarshalText() (text []byte, err error) {
 	var ss State
-	s.Format(&ss, 's')
+	s.Format(&ss, 'v')
 	return ss.b, nil
 }

--- a/uint64.go
+++ b/uint64.go
@@ -4,6 +4,7 @@ import (
 	"encoding"
 	"encoding/json"
 	"fmt"
+	"strconv"
 )
 
 var (
@@ -20,11 +21,20 @@ func (s Uint64) Format(f fmt.State, c rune) {
 }
 
 func (s Uint64) MarshalJSON() ([]byte, error) {
-	return json.Marshal(nil)
+	var ss State
+	s.Format(&ss, 'v')
+	if len(ss.b) == 0 {
+		return json.Marshal(nil)
+	}
+	v, err := strconv.ParseUint(string(ss.b), 10, 64)
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(v)
 }
 
 func (s Uint64) MarshalText() (text []byte, err error) {
 	var ss State
-	s.Format(&ss, 's')
+	s.Format(&ss, 'v')
 	return ss.b, nil
 }

--- a/uint8.go
+++ b/uint8.go
@@ -4,6 +4,7 @@ import (
 	"encoding"
 	"encoding/json"
 	"fmt"
+	"strconv"
 )
 
 var (
@@ -20,11 +21,20 @@ func (s Uint8) Format(f fmt.State, c rune) {
 }
 
 func (s Uint8) MarshalJSON() ([]byte, error) {
-	return json.Marshal(nil)
+	var ss State
+	s.Format(&ss, 'v')
+	if len(ss.b) == 0 {
+		return json.Marshal(nil)
+	}
+	v, err := strconv.ParseUint(string(ss.b), 10, 8)
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(uint8(v))
 }
 
 func (s Uint8) MarshalText() (text []byte, err error) {
 	var ss State
-	s.Format(&ss, 's')
+	s.Format(&ss, 'v')
 	return ss.b, nil
 }


### PR DESCRIPTION
Currently MarshalJSON/Text uses result of Format*Fn only for String, while all other types ignores it.
This PR fixes this, and also consistently use `'v'` formatting everywhere.

I've a test for this, but it comes with a new feature and I'd like to avoid mixing fix with the feature, so this PR won't include it. You can see it here: https://github.com/powerman/sensitive/commit/19629b3b202e73fc9943aaa911cb804e9a2eb5b4 and I'll open PR with it if/when you'll merge my other PRs because it depends on them.